### PR TITLE
Fix Read the Docs build: bump build.os to ubuntu-24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   apt_packages:
     - graphviz
   tools:


### PR DESCRIPTION
## Problem

Read the Docs builds are failing at config validation, before any install step runs (e.g. [build #33466988](https://app.readthedocs.org/projects/cosmology-compat-astropy/builds/33466988/)):

```
Config validation error in build.os. Expected one of
(ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest),
got type str (ubuntu-20.04).
```

Read the Docs has retired the `ubuntu-20.04` build image, so the pinned `build.os: ubuntu-20.04` in `.readthedocs.yaml` is no longer accepted.

## Fix

Bump `build.os` to `ubuntu-24.04`, a currently-supported image.

The docs themselves build cleanly — verified locally with `sphinx -W` (Sphinx 7.4.7). The only failure was the retired build image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)